### PR TITLE
fix: get-caller-identity not providing the correct role

### DIFF
--- a/awsconfig/awsconfig.go
+++ b/awsconfig/awsconfig.go
@@ -64,7 +64,7 @@ func (c *awsConfig) toCredentialsINI() string {
 }
 
 func (c *awsConfig) toConfigINI() string {
-	return fmt.Sprintf("[default]\nrole_arn = %s\nsource_profile = default\n", c.RoleArn)
+	return fmt.Sprintf("[default]\n")
 }
 
 // atomically update ~/.aws/credentials and ~/.aws/config

--- a/awsconfig/awsconfig_test.go
+++ b/awsconfig/awsconfig_test.go
@@ -1,0 +1,17 @@
+package awsconfig
+
+import (
+	"testing"
+)
+
+func TestAWSConfigToConfigINI(t *testing.T) {
+
+	c := &awsConfig{} 
+
+	result := c.toConfigINI()
+	expected := "[default]\n"
+
+	if result != expected {
+		t.Errorf("c.toConfigINI() returned %s, expected %s", result, expected)
+	}
+}


### PR DESCRIPTION
While testing with Daniel on his EC2 setup we found that there's a silent error happening when trying to assume the role for our on-prem test client.

**Pre-reqs:**
- awscli

### Steps to reproduce:
issue an `aws sts-get-caller-identity`

### Results:
```bash
[ec2-user@ip-10-0-3-24 ~]$ kubectl exec -it cerby-d58784c77-d95z7 -c base -- bash
root@cerby-d58784c77-d95z7:/usr/local/src# aws sts get-caller-identity

An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::516187479401:assumed-role/development-on_prem_client_one-role/00dde5f80df51a681c5528f9b4dcd86cc3 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::516187479401:role/development-on_prem_client_one-role
```

**Expected:**
```
root@cerby-d58784c77-d95z7:/usr/local/src# aws sts get-caller-identity
{
    "UserId": "AROAXQLZL3VU74X6JZSOZ:00dde5f80df51a681c5528f9b4dcd86cc3",
    "Account": "516187479401",
    "Arn": "arn:aws:sts::516187479401:assumed-role/development-on_prem_client_one-role/00dde5f80df51a681c5528f9b4dcd86cc3"
}

```

**Troubleshooting:**
Once a session is initiated you can use the keys, secrets and tokens to ping the AWS API, we knew that the credentials were right and exposed the correct level of access to our systems. However the `caller-identity` was not being set correctly by the `aws-cli` tool 

Fix and suppositions:
There might be something going on with the awscli version that gets installed on our container in EC2s by default using `apt` and after carefully looking at the files it seems that if we add content beyond the profile name inside `~/.aws/config` the auth process breaks.  Not even `aws xyzabc --debug` caught this. 
